### PR TITLE
Added "3.8" to version line in metadata.json

### DIFF
--- a/window_buttons@biox.github.com/metadata.json
+++ b/window_buttons@biox.github.com/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.4", "3.6"], 
+  "shell-version": ["3.4", "3.6", "3.8"],
   "uuid": "window_buttons@biox.github.com",
   "name": "Window Buttons",
   "description": "Add minimize, maximize and close buttons to the panel. Originally by Josiah Messiah, maintained by m.c. See homepage for instructions.",


### PR DESCRIPTION
This simple fix makes this extension work wonderfully under gnome-shell 3.8. Tested on arch linux. Also, various other users reported that this fix works without problem. See the comments in the Gnome Extensions page.
